### PR TITLE
Use the black code formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 # Bank2YNAB4
 Converts from bank transactions exported as CSV to the format accepted by YNAB4.
 

--- a/bank2ynab.pyw
+++ b/bank2ynab.pyw
@@ -8,17 +8,19 @@ from src.config import BankConfig
 PADX = 12
 PADY = 10
 
-BANK_DIR = Path('./banks')
+BANK_DIR = Path("./banks")
 
 ###################################
 #           GUI-code
 ###################################
+
 
 class Application(Tk):
     """
     Main window that can repace the frame that is shown
     https://stackoverflow.com/questions/7546050/switch-between-two-frames-in-tkinter
     """
+
     def __init__(self):
         Tk.__init__(self)
         self._frame = None
@@ -46,25 +48,25 @@ class BankSelection(Frame):
 
     def createWidgets(self):
         self.label = Label(self, text="Choose Your Bank:")
-        self.label.grid(column=0, row=0, sticky='W', ipadx=2)
+        self.label.grid(column=0, row=0, sticky="W", ipadx=2)
 
         banknames = [b.name for b in self.banks]
         self.bankName = StringVar()
         self.bankName.set(banknames[0])
 
         self.bankChosen = Combobox(self, width=12, textvariable=self.bankName)
-        self.bankChosen['values'] = banknames
+        self.bankChosen["values"] = banknames
         self.bankChosen.grid(column=1, row=0)
 
         self.confirm = Button(self, text="Ok", command=self.convert)
-        self.confirm.grid(column=0, row=1, columnspan=2, sticky='E', pady=5)
+        self.confirm.grid(column=0, row=1, columnspan=2, sticky="E", pady=5)
 
     def convert(self):
         try:
             inputPath = self.getFile()
             bank = self.banks[self.bankChosen.current()]
         except ValueError as e:
-            pass # No file selected
+            pass  # No file selected
         else:
             try:
                 result = bank2ynab(bank, inputPath)
@@ -73,13 +75,11 @@ class BankSelection(Frame):
                 Error(self, e)
 
     def getFile(self) -> Path:
-        inputPath = askopenfilename(
-                    filetypes=[('CSV files', '*.csv')],
-                    initialdir='.')
+        inputPath = askopenfilename(filetypes=[("CSV files", "*.csv")], initialdir=".")
         if inputPath:
             return Path(inputPath)
         else:
-            raise ValueError('No file selected')
+            raise ValueError("No file selected")
 
 
 class Report(Frame):
@@ -89,18 +89,20 @@ class Report(Frame):
         self.createLabels(args)
 
         self.exitButton = Button(self, text="Exit", command=self.master.destroy)
-        self.exitButton.grid(column=0, row=4, sticky='E')
+        self.exitButton.grid(column=0, row=4, sticky="E")
 
     def createLabels(self, args):
-        success, blankRows, ignoredRows, linesRead, rowsParsed= args
+        success, blankRows, ignoredRows, linesRead, rowsParsed = args
 
-        readStats = f'{linesRead}/{linesRead+blankRows+ignoredRows} rows read'
-        if(blankRows+ignoredRows != 0):
-            ignoreStats = f' (ignored {blankRows} blank rows and ' \
-                    f'{ignoredRows} transactions found in accignore).'
+        readStats = f"{linesRead}/{linesRead+blankRows+ignoredRows} rows read"
+        if blankRows + ignoredRows != 0:
+            ignoreStats = (
+                f" (ignored {blankRows} blank rows and "
+                f"{ignoredRows} transactions found in accignore)."
+            )
             readStats = readStats + ignoreStats
 
-        parsedStats = f'{rowsParsed}/{linesRead} rows parsed '
+        parsedStats = f"{rowsParsed}/{linesRead} rows parsed "
 
         if not success:
             self.status = "Conversion failed."
@@ -108,23 +110,24 @@ class Report(Frame):
             self.status = "YNAB csv-file successfully written."
 
         self.statusLabel = Label(self, text=self.status)
-        self.statusLabel.grid(column=0, row=0, sticky='W', pady=5)
+        self.statusLabel.grid(column=0, row=0, sticky="W", pady=5)
 
-        self.readStatsLabel  = Label(self, text=readStats)
-        self.readStatsLabel.grid(column=0, row=1, sticky='W')
+        self.readStatsLabel = Label(self, text=readStats)
+        self.readStatsLabel.grid(column=0, row=1, sticky="W")
 
         self.parsedStatsLabel = Label(self, text=parsedStats)
-        self.parsedStatsLabel.grid(column=0, row=3, sticky='W')
+        self.parsedStatsLabel.grid(column=0, row=3, sticky="W")
 
 
 class Error(Toplevel):
     """Pop-up for displaying an error message"""
+
     def __init__(self, master, arg):
         Toplevel.__init__(self, master, padx=PADX, pady=PADY)
         self.title("Error")
 
         self.msg = Message(self, text=arg, aspect=380)
-        self.msg.grid(column=0, row=0,  pady=5)
+        self.msg.grid(column=0, row=0, pady=5)
         self.columnconfigure(0, minsize=180)
 
         button = Button(self, text="Dismiss", command=self.destroy)

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,43 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "black"
+version = "21.12b0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
+tomli = ">=0.2.6,<2.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.3)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.0.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -30,7 +67,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "hypothesis"
-version = "6.24.0"
+version = "6.31.6"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -41,11 +78,11 @@ attrs = ">=19.2.0"
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2021.5)"]
 cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
 dateutil = ["python-dateutil (>=1.4)"]
-django = ["pytz (>=2014.1)", "django (>=2.2)"]
+django = ["django (>=2.2)"]
 dpcontracts = ["dpcontracts (>=0.4)"]
 ghostwriter = ["black (>=19.10b0)"]
 lark = ["lark-parser (>=0.6.5)"]
@@ -54,7 +91,7 @@ pandas = ["pandas (>=0.25)"]
 pytest = ["pytest (>=4.6)"]
 pytz = ["pytz (>=2014.1)"]
 redis = ["redis (>=3.0.0)"]
-zoneinfo = ["importlib-resources (>=3.3.0)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+zoneinfo = ["importlib-resources (>=3.3.0)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2021.5)"]
 
 [[package]]
 name = "iniconfig"
@@ -65,15 +102,43 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
-version = "21.0"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.4.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -89,15 +154,15 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.0"
+version = "3.0.6"
 description = "Python parsing module"
 category = "dev"
 optional = false
@@ -145,16 +210,24 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.1"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "75bf214ae62492fca96dc9567068d6ce420522ed65d77e7eb82560e5045db1e1"
+content-hash = "1223a2dc37533e3f87960a5f65ca41c88c11d4b2313f33f8381913c939a6c41d"
 
 [metadata.files]
 atomicwrites = [
@@ -165,33 +238,53 @@ attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
+black = [
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
+]
+click = [
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
+]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.24.0-py3-none-any.whl", hash = "sha256:17d03a15139b65b6e502e84c2c07a4f482cb92159ad43eac6c0b6b0fbdd3553a"},
-    {file = "hypothesis-6.24.0.tar.gz", hash = "sha256:ef53bd1c4756436be2e8d4a2e16f6f5ffbca7acbe8041e6872aea16176ff3806"},
+    {file = "hypothesis-6.31.6-py3-none-any.whl", hash = "sha256:fbd31da5174f3da8d062017302071967b239a1b397d0e3181a44d43346bc6def"},
+    {file = "hypothesis-6.31.6.tar.gz", hash = "sha256:d54be6a80b160ad5ea4209b01a0d72e31d910510ed7142fa9907861911800771"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.0-py3-none-any.whl", hash = "sha256:d487599e9fb0dc36bee6b5c183c6fc5bd372ce667736f3d430ab7d842a54a35a"},
-    {file = "pyparsing-3.0.0.tar.gz", hash = "sha256:001cad8d467e7a9248ef9fd513f5c0d39afcbcb9a43684101853bd0ab962e479"},
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -206,6 +299,10 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
-    {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ tomli = "^1.2.1"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"
 hypothesis = "^6.14.1"
+black = "^21.12b0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/fix_revolut/fix_revolut.py
+++ b/scripts/fix_revolut/fix_revolut.py
@@ -3,26 +3,36 @@ import re
 from pathlib import Path
 from typing import Optional
 
-class NumberQuoter():
-    def __init__(self, *, thousands_sep: str=',', decimal_sep: str='.', n_decimals: int=2) -> None:
-        self._group_tag = 'largeamount'
 
-        match_number_with_thousands_sep = r'([0-9]{{1,3}}{})+[0-9]{{3}}{}[0-9]{{{}}}(?![0-9])'.format(
-            re.escape(thousands_sep), re.escape(decimal_sep), n_decimals)
-        self._pattern =  re.compile(r'(?!")(?=[0-9])(?P<{}>{})(?!")'.format(
-            self._group_tag, match_number_with_thousands_sep)
+class NumberQuoter:
+    def __init__(
+        self, *, thousands_sep: str = ",", decimal_sep: str = ".", n_decimals: int = 2
+    ) -> None:
+        self._group_tag = "largeamount"
+
+        match_number_with_thousands_sep = (
+            r"([0-9]{{1,3}}{})+[0-9]{{3}}{}[0-9]{{{}}}(?![0-9])".format(
+                re.escape(thousands_sep), re.escape(decimal_sep), n_decimals
+            )
+        )
+        self._pattern = re.compile(
+            r'(?!")(?=[0-9])(?P<{}>{})(?!")'.format(
+                self._group_tag, match_number_with_thousands_sep
+            )
         )
 
     def quote_str_number(self, string: str) -> str:
-        """ Surround numbers with thousands seperators in quotes.
+        """Surround numbers with thousands seperators in quotes.
         Only numbers that aren't already in quotation marks will be replaced.
         """
         return self._pattern.sub(fr'"\g<{self._group_tag}>"', string)
 
 
-def quote_numbers(file: Path, *,
-    replace: bool=False,
-    out_dir: Optional[Path]=None,
+def quote_numbers(
+    file: Path,
+    *,
+    replace: bool = False,
+    out_dir: Optional[Path] = None,
     **numberquoter_kwargs,
 ) -> Path:
     """
@@ -65,14 +75,14 @@ def quote_numbers(file: Path, *,
     elif out_dir is not None and (not out_dir.is_dir()):
         raise ValueError(f"{out_dir=} is not a directory")
 
-    nq =  NumberQuoter(**numberquoter_kwargs)
+    nq = NumberQuoter(**numberquoter_kwargs)
     new_file_contents = nq.quote_str_number(file.read_text())
 
-    new_name = file.stem + '_OUT' + file.suffix
+    new_name = file.stem + "_OUT" + file.suffix
     if not replace:
         file = file.with_name(new_name)
 
-    if out_dir is not None: # guaranteed to be a directory
+    if out_dir is not None:  # guaranteed to be a directory
         file = out_dir / new_name
 
     file.write_text(new_file_contents)
@@ -81,23 +91,34 @@ def quote_numbers(file: Path, *,
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Makes sure all values with thousands separators are in quotes in an exported CSV file from Revolut.")
-    parser.add_argument('file', type=Path,
-        help="path to the CSV statement file")
+    parser = argparse.ArgumentParser(
+        description="Makes sure all values with thousands separators are in quotes in an exported CSV file from Revolut."
+    )
+    parser.add_argument("file", type=Path, help="path to the CSV statement file")
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--replace', action="store_true",
-        help="replace the original statement file")
-    group.add_argument('--out', type=Path,
-        help="write the updated file to this directory")
-    parser.add_argument("-ts", "--thousands-sep", type=str, default=',',
-        help="the thousands separator")
-    parser.add_argument("-ds", "--decimal_sep", type=str, default='.',
-        help="the decimal separator")
-    parser.add_argument("-p", "--percision", type=int, default=2,
-        help="number of decimal digits used in the input file")
+    group.add_argument(
+        "--replace", action="store_true", help="replace the original statement file"
+    )
+    group.add_argument(
+        "--out", type=Path, help="write the updated file to this directory"
+    )
+    parser.add_argument(
+        "-ts", "--thousands-sep", type=str, default=",", help="the thousands separator"
+    )
+    parser.add_argument(
+        "-ds", "--decimal_sep", type=str, default=".", help="the decimal separator"
+    )
+    parser.add_argument(
+        "-p",
+        "--percision",
+        type=int,
+        default=2,
+        help="number of decimal digits used in the input file",
+    )
 
     args = parser.parse_args()
-    quote_numbers(args.file,
+    quote_numbers(
+        args.file,
         replace=args.replace,
         out_dir=args.out,
         thousands_sep=args.thousands_sep,
@@ -105,5 +126,6 @@ def main():
         n_decimals=args.percision,
     )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/config.py
+++ b/src/config.py
@@ -7,13 +7,14 @@ from typing import Any, Callable
 
 
 def _assert_not_empty(column_name: str) -> str:
-    if column_name == '':
-        raise ValueError('Empty column name')
+    if column_name == "":
+        raise ValueError("Empty column name")
 
     return column_name
 
+
 class TransactionFormat(enum.Flag):
-    """ Format for a CSV transaction column
+    """Format for a CSV transaction column
     The semantics of a transaction column can in different depending
     on wether or not the column is signed (AMOUNT) or unsigned
     (OUTFLOW or INFLOW).
@@ -24,12 +25,14 @@ class TransactionFormat(enum.Flag):
     AMOUNT: the column describes a signed transaction amount
             (can be positive or negative)
     """
+
     OUTFLOW = enum.auto()
     INFLOW = enum.auto()
     AMOUNT = OUTFLOW & INFLOW
 
+
 @dataclass(frozen=True)
-class TransactionColumn():
+class TransactionColumn:
     header_key: str
     transaction_format: TransactionFormat
 
@@ -42,10 +45,11 @@ class TransactionColumn():
         return cls(header_key=header_key, transaction_format=TransactionFormat.INFLOW)
 
     @classmethod
-    def from_config(cls, outflows: str | list[str], inflows: str | list[str]) -> list["TransactionColumn"]:
+    def from_config(
+        cls, outflows: str | list[str], inflows: str | list[str]
+    ) -> list["TransactionColumn"]:
         def to_list(val: str | list[str]) -> list[str]:
-            """ Type check the value
-            """
+            """Type check the value"""
             is_str = lambda v: isinstance(v, str)
             if is_str(val):
                 return [_assert_not_empty(val)]
@@ -54,7 +58,9 @@ class TransactionColumn():
                 raise TypeError(f"Key '{val}' is {type(val)}, not a str or list")
             elif not all((is_str(v) for v in val)):
                 not_str = list(filter(lambda v: not is_str(v), val))
-                raise TypeError(f"Expected only list of str, but found {not_str} in list")
+                raise TypeError(
+                    f"Expected only list of str, but found {not_str} in list"
+                )
 
             return list(map(_assert_not_empty, val))
 
@@ -68,7 +74,9 @@ class TransactionColumn():
         transaction_columns = {tc.header_key: tc for tc in outflows_tc | inflows_tc}
         amount_keys = set(outflows_list) & set(inflows_list)
         for k in amount_keys:
-            transaction_columns[k] = cls(header_key=k, transaction_format=TransactionFormat.AMOUNT)
+            transaction_columns[k] = cls(
+                header_key=k, transaction_format=TransactionFormat.AMOUNT
+            )
 
         return list(transaction_columns.values())
 
@@ -80,12 +88,17 @@ class CurrencyFormat:
 
     def __post_init__(self):
         if len(self.thousands_sep) > 1:
-            raise ValueError("The thousands separator must be empty or a single character, not '{thousands_sep}'")
+            raise ValueError(
+                "The thousands separator must be empty or a single character, not '{thousands_sep}'"
+            )
 
         if len(self.decimal_point) != 1:
-            raise ValueError("The decimal separator must be a single character, not '{decimal_point}'")
+            raise ValueError(
+                "The decimal separator must be a single character, not '{decimal_point}'"
+            )
 
-class BankConfig():
+
+class BankConfig:
     def __init__(
         self,
         name: str,
@@ -95,51 +108,58 @@ class BankConfig():
         date_column: str,
         outflow_columns: str | list[str],
         inflow_columns: str | list[str],
-        payee_column: (str | None)=None,
-        memo_column: (str | None)=None,
-        category_column: (str | None)=None,
-        csv_delimiter: (str | None)=None,
-        normalizer: (Callable[[str], str] | None)=None,
+        payee_column: (str | None) = None,
+        memo_column: (str | None) = None,
+        category_column: (str | None) = None,
+        csv_delimiter: (str | None) = None,
+        normalizer: (Callable[[str], str] | None) = None,
     ):
-        if name == '':
+        if name == "":
             raise ValueError(f"The name column name is empty; {name=}")
         self.name = name
 
-        if date_column == '':
+        if date_column == "":
             raise ValueError(f"The date column name is empty; {date_column=}")
         self._date_column = date_column
 
-        if date_format == '':
+        if date_format == "":
             raise ValueError(f"The date format string is empty; {date_format=}")
         self.date_format = date_format
 
-        self.csv_delimiter = ',' if csv_delimiter is None else csv_delimiter
+        self.csv_delimiter = "," if csv_delimiter is None else csv_delimiter
         if len(self.csv_delimiter) != 1:
-            raise ValueError(f"The CSV delimiter must be a single character, not '{csv_delimiter}'")
+            raise ValueError(
+                f"The CSV delimiter must be a single character, not '{csv_delimiter}'"
+            )
 
         self.currency_format = CurrencyFormat(
             thousands_sep=thousands_separator,
             decimal_point=decimal_point,
         )
-        if self.csv_delimiter == self.currency_format.decimal_point == ',':
+        if self.csv_delimiter == self.currency_format.decimal_point == ",":
             warnings.warn(
                 "Both the delimiter and decimal point characters are ',' - make "
-                "sure all transaction values are properly quoted", UserWarning)
-        elif csv_delimiter == self.currency_format.thousands_sep == ',':
+                "sure all transaction values are properly quoted",
+                UserWarning,
+            )
+        elif csv_delimiter == self.currency_format.thousands_sep == ",":
             warnings.warn(
                 "Both the delimiter and thousands separator characters are ',' - make "
-                "sure all transaction values are properly quoted", UserWarning)
-
+                "sure all transaction values are properly quoted",
+                UserWarning,
+            )
 
         self._payee_column = payee_column
         self._memo_column = memo_column
         self._category_column = category_column
 
-        self._transaction_columns = TransactionColumn.from_config(outflow_columns, inflow_columns)
+        self._transaction_columns = TransactionColumn.from_config(
+            outflow_columns, inflow_columns
+        )
 
         self.normalizer = lambda x: x
         if normalizer is not None:
-            self.normalizer = normalizer # string pre-processing function
+            self.normalizer = normalizer  # string pre-processing function
 
     @property
     def date_column(self):
@@ -147,7 +167,7 @@ class BankConfig():
 
     @property
     def transaction_columns(self) -> list[TransactionColumn]:
-        normalized=[]
+        normalized = []
         for tc in self._transaction_columns:
             ntc = TransactionColumn(
                 header_key=self.normalizer(tc.header_key),
@@ -179,29 +199,29 @@ class BankConfig():
 
     @classmethod
     def from_file(cls, toml_config: Path):
-        with toml_config.open(mode='rb') as f:
+        with toml_config.open(mode="rb") as f:
             config = tomli.load(f)
         return cls.from_dict(config)
 
     @classmethod
     def from_dict(cls, toml_config: dict[str, Any]):
-        name = toml_config['name']
+        name = toml_config["name"]
 
-        currency_config = toml_config['currency_format']
-        thousands_separator = currency_config['thousands_separator']
-        decimal_point = currency_config['decimal_point']
+        currency_config = toml_config["currency_format"]
+        thousands_separator = currency_config["thousands_separator"]
+        decimal_point = currency_config["decimal_point"]
 
-        csv_config: dict[str, Any] = toml_config['csv']
-        date_format = csv_config['date_format']
-        csv_delimiter = csv_config.get('delimiter', ',')
+        csv_config: dict[str, Any] = toml_config["csv"]
+        date_format = csv_config["date_format"]
+        csv_delimiter = csv_config.get("delimiter", ",")
 
-        ynab_mapping = toml_config['ynab_mapping']
-        date_column = ynab_mapping['date']
-        outflow_columns = ynab_mapping['outflow']
-        inflow_columns = ynab_mapping['inflow']
-        payee_column = ynab_mapping.get('payee')
-        memo_column = ynab_mapping.get('memo')
-        category_column = ynab_mapping.get('category')
+        ynab_mapping = toml_config["ynab_mapping"]
+        date_column = ynab_mapping["date"]
+        outflow_columns = ynab_mapping["outflow"]
+        inflow_columns = ynab_mapping["inflow"]
+        payee_column = ynab_mapping.get("payee")
+        memo_column = ynab_mapping.get("memo")
+        category_column = ynab_mapping.get("category")
 
         return cls(
             name=name,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,10 @@ from util import load_template_config
 
 import pytest
 
+
 @pytest.fixture
 def bank_config_files() -> list[Path]:
-    config_files = [c for c in Path('banks').iterdir() if c.suffix == '.toml']
+    config_files = [c for c in Path("banks").iterdir() if c.suffix == ".toml"]
     if len(config_files) == 0:
         raise FileNotFoundError("No TOML config files found in the 'banks/' directory")
 
@@ -21,74 +22,95 @@ def valid_config_dict() -> dict[str, str | list[str]]:
             "date_format": "this format is not validated in the config",
         },
         "currency_format": {
-            "thousands_separator": '',
-            "decimal_point": '.',
+            "thousands_separator": "",
+            "decimal_point": ".",
         },
         "ynab_mapping": {
             "date": "Date",
             "outflow": "Outflow",
             "inflow": "Inflow",
-        }
+        },
     }
+
 
 def test_valid_config_dict(valid_config_dict):
     BankConfig.from_dict(valid_config_dict)
+
 
 def test_parse_bank_configs(bank_config_files):
     for config in bank_config_files:
         BankConfig.from_file(config)
 
+
 def test_load_template_config():
     config = load_template_config()
     BankConfig.from_file(config)
 
+
 # ----------- Test invalid inputs -----------
+
 
 def test_invalid_args():
     with pytest.raises((ValueError, TypeError)):
-        BankConfig(name=None, date_column=None, date_format=None, thousands_separator=None, decimal_point=None, outflow_columns=[], inflow_columns=[])
+        BankConfig(
+            name=None,
+            date_column=None,
+            date_format=None,
+            thousands_separator=None,
+            decimal_point=None,
+            outflow_columns=[],
+            inflow_columns=[],
+        )
+
 
 def test_invalid_config_empty():
     config = {}
     with pytest.raises(KeyError):
         BankConfig.from_dict(config)
 
+
 def test_invalid_config_missing_date_from_dict(valid_config_dict):
-    del valid_config_dict['ynab_mapping']['date']
+    del valid_config_dict["ynab_mapping"]["date"]
     with pytest.raises(KeyError):
         BankConfig.from_dict(valid_config_dict)
 
+
 def test_invalid_config_empty_date_from_dict(valid_config_dict):
-    valid_config_dict['ynab_mapping']['date'] = ''
+    valid_config_dict["ynab_mapping"]["date"] = ""
     with pytest.raises(ValueError):
         BankConfig.from_dict(valid_config_dict)
 
+
 def test_invalid_config_missing_date_format_from_dict(valid_config_dict):
-    del valid_config_dict['csv']['date_format']
+    del valid_config_dict["csv"]["date_format"]
     with pytest.raises(KeyError):
         BankConfig.from_dict(valid_config_dict)
+
 
 def test_invalid_config_missing_inflow(valid_config_dict):
-    del valid_config_dict['ynab_mapping']['inflow']
+    del valid_config_dict["ynab_mapping"]["inflow"]
     with pytest.raises(KeyError):
         BankConfig.from_dict(valid_config_dict)
+
 
 def test_invalid_config_missing_outflow(valid_config_dict):
-    del valid_config_dict['ynab_mapping']['outflow']
+    del valid_config_dict["ynab_mapping"]["outflow"]
     with pytest.raises(KeyError):
         BankConfig.from_dict(valid_config_dict)
 
+
 def test_invalid_config_missing_currency_format(valid_config_dict):
-    del valid_config_dict['currency_format']
+    del valid_config_dict["currency_format"]
     with pytest.raises(KeyError):
         BankConfig.from_dict(valid_config_dict)
+
 
 def test_invalid_config_invalid_currency_format_thousands(valid_config_dict):
     fmts = [
-        {'thousands_separator': ',,', 'decimal_point': '.'},
-        {'thousands_separator': '', 'decimal_point': '..'},
+        {"thousands_separator": ",,", "decimal_point": "."},
+        {"thousands_separator": "", "decimal_point": ".."},
     ]
     for fmt in fmts:
-        valid_config_dict['currency_format'] = fmt
+        valid_config_dict["currency_format"] = fmt
         with pytest.raises(ValueError):
             BankConfig.from_dict(valid_config_dict)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -5,36 +5,40 @@ from scripts.fix_revolut import fix_revolut
 from src.converter import bank2ynab
 from src.config import BankConfig
 
+
 def test_ica_banken_v1():
-    csv_path = load_test_example('ica_banken_v1.csv')
-    toml_path = load_bank_config('ica_banken_v1.toml')
+    csv_path = load_test_example("ica_banken_v1.csv")
+    toml_path = load_bank_config("ica_banken_v1.toml")
     ica_config = BankConfig.from_file(toml_path)
 
     expect = (True, 0, 0, 5, 5)
     result = bank2ynab(ica_config, csv_path)
     assert expect == result
 
+
 def test_nordea_v2():
-    csv_path = load_test_example('nordea_v2.csv')
-    toml_path = load_bank_config('nordea_v2.toml')
+    csv_path = load_test_example("nordea_v2.csv")
+    toml_path = load_bank_config("nordea_v2.toml")
     nordea_config = BankConfig.from_file(toml_path)
 
     expect = (True, 0, 0, 4, 4)
     result = bank2ynab(nordea_config, csv_path)
     assert expect == result
 
+
 def test_revolut_v2():
-    csv_path = load_test_example('revolut_v2.csv')
-    toml_path = load_bank_config('revolut_v2.toml')
+    csv_path = load_test_example("revolut_v2.csv")
+    toml_path = load_bank_config("revolut_v2.toml")
     revolut_config = BankConfig.from_file(toml_path)
 
     expect = (True, 0, 0, 5, 5)
     result = bank2ynab(revolut_config, csv_path)
     assert expect == result
 
+
 def test_identity():
-    csv_path = load_test_example('example_ynab.csv')
-    toml_path =  load_template_config()
+    csv_path = load_test_example("example_ynab.csv")
+    toml_path = load_template_config()
     template_config = BankConfig.from_file(toml_path)
 
     expect = (True, 0, 0, 2, 2)
@@ -42,6 +46,6 @@ def test_identity():
     assert expect == result
 
     net_bank = net_flow(csv_path)
-    net_converted = net_flow(Path.cwd() / 'ynabImport.csv')
+    net_converted = net_flow(Path.cwd() / "ynabImport.csv")
     assert net_bank == net_converted
     print(f"{net_converted=}")

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,22 +4,27 @@ from pathlib import Path
 
 
 def examples_dir():
-    return find_dir('example_csv')
+    return find_dir("example_csv")
+
 
 def bank_configs_dir():
-    return find_dir('banks')
+    return find_dir("banks")
+
 
 def find_dir(dirname: str) -> Path:
-    """ Find the path to a directory
+    """Find the path to a directory
     Recursively (from the current directory) look for the the directory.
 
     Raises RuntimeError if the directory could not be found.
     """
     dir_path = _find_dir(dirname, Path.cwd())
     if dir_path is None:
-        raise RuntimeError(f"no directory named '{dirname}' could be found relative to {Path.cwd()}")
+        raise RuntimeError(
+            f"no directory named '{dirname}' could be found relative to {Path.cwd()}"
+        )
 
     return dir_path
+
 
 def _find_dir(dirname: str, dir: Path) -> Path | None:
     dirs = (d for d in dir.iterdir() if d.is_dir())
@@ -27,20 +32,24 @@ def _find_dir(dirname: str, dir: Path) -> Path | None:
         if d.name == dirname:
             return d
 
-        recurse = _find_dir(dirname, d) # dfs-style
+        recurse = _find_dir(dirname, d)  # dfs-style
         if recurse is not None:
             return recurse
 
     return None
 
+
 def load_test_example(filename: str) -> Path:
     return _file_in_dir(filename, dir=examples_dir())
+
 
 def load_bank_config(filename: str) -> Path:
     return _file_in_dir(filename, dir=bank_configs_dir())
 
+
 def load_template_config():
     return _file_in_dir("template.toml", dir=bank_configs_dir() / "template")
+
 
 def _file_in_dir(filename: str, dir: Path) -> Path:
     for file in dir.iterdir():
@@ -50,19 +59,22 @@ def _file_in_dir(filename: str, dir: Path) -> Path:
             return file
     raise FileNotFoundError(f"{filename} could be found in {dir}")
 
-def _str_to_decimal(decimal: str ) -> Decimal:
-    if decimal == '':
-        return Decimal('0')
+
+def _str_to_decimal(decimal: str) -> Decimal:
+    if decimal == "":
+        return Decimal("0")
 
     return Decimal(decimal)
 
 
 def net_flow(ynab_csv: Path) -> Decimal:
-    net = Decimal('0')
-    with ynab_csv.open('r', encoding="utf-8-sig", newline='') as f:
+    net = Decimal("0")
+    with ynab_csv.open("r", encoding="utf-8-sig", newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            outflow, inflow = [_str_to_decimal(row[key]) for key in ('Outflow', 'Inflow')]
+            outflow, inflow = [
+                _str_to_decimal(row[key]) for key in ("Outflow", "Inflow")
+            ]
             net = net + inflow - outflow
 
     return net


### PR DESCRIPTION
Format the project with [black](https://github.com/psf/black).

### TODO
- [x] Await python 3.10 syntax support (black fails to format `converter.py` since it has a `match` statement).
  - They've implemented a workaround until [they've switched to a new parser](https://github.com/psf/black/issues/2318)