### PR TITLE
Parse the value of monetary colums

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Converts from bank transactions exported as CSV to the format accepted by YNAB4.
 
 ## Why YNAB4?
 
-Besides the whole UX aspect, YNAB4 was great for two reasons.
+Besides being much nicer to use than a simple spreadsheet, YNAB4 was great for two reasons:
 1. One-time cost.
 2. Data stored locally, with the option of uploading to Dropbox.
 
-The new, web-based YNAB follows a monthly subscription  model.
+The new, web-based YNAB follows a monthly subscription model.
 Paying $7 to make my monthly budget just does not make sense for me.
 Also, I don't want to be forced to store all my bank data on their servers.
 
@@ -26,7 +26,7 @@ Using Bank2YNAB4 is straightforward:
 1. Run `bank2ynab.py` to launch the application.
 2. Select one of the available banks from the drop-down menu.
 3. From the dialog, find and select the CSV file from the bank (a header is assumed to exist in the CSV-file).
-4. If conversion succeeded, then the converted CSV file is written to `ynabImport.csv` in the same directory as `bank2ynab.py`.
+4. If conversion succeeded, then the converted CSV file is written to `ynabImport.csv` in the same directory as `bank2ynab.pyw`.
 
 ## List of supported banks
 
@@ -42,7 +42,7 @@ A [template config](banks/template/template.toml) is provided as a starting poin
 Filling out the template should hopefully be clear from the comments.
 Nevertheless, a short description can be helpful:
 1. Create a new bank config by copying and renaming the template.
-2. Give the bank an appropriate `name` and specify the delimiter and date format used in the bank's CSV statements in the `csv` table.
+2. Give the bank an appropriate `name` and specify all delimiters and the date format used.
 3. Fill out the `ynab_mapping` table with the corresponding column names from the bank's CSV statement.
 
 Some keys in the template's `ynab_mapping` table are optional, however:

--- a/banks/ica_banken_v1.toml
+++ b/banks/ica_banken_v1.toml
@@ -1,6 +1,10 @@
 
 name = "ICA Banken"
 
+[currency_format]
+thousands_separator = ' '
+decimal_point = ','
+
 [csv]
 delimiter = ';'
 date_format = '%Y-%m-%d'

--- a/banks/nordea_v2.toml
+++ b/banks/nordea_v2.toml
@@ -1,5 +1,9 @@
 name = "Nordea"
 
+[currency_format]
+thousands_separator = ''
+decimal_point = ','
+
 [csv]
 delimiter = ';'
 date_format = '%Y-%m-%d'

--- a/banks/revolut_v1.toml
+++ b/banks/revolut_v1.toml
@@ -1,5 +1,9 @@
 name = "Revolut (SEK)"
 
+[currency_format]
+thousands_separator = ','
+decimal_point = '.'
+
 [csv]
 delimiter = ','
 date_format = '%d %b %Y'
@@ -10,4 +14,4 @@ outflow = 'Paid Out (SEK)'
 inflow = 'Paid In (SEK)'
 payee = 'Description'
 memo = 'Notes'
-category= 'Category'
+category = 'Category'

--- a/banks/template/template.toml
+++ b/banks/template/template.toml
@@ -1,8 +1,12 @@
 name = "The name of your bank"
 
 [csv]
-delimiter = ',' # defaults to ','
+delimiter = ','          # defaults to ','
 date_format = '%Y-%m-%d' # a valid `datetime.strptime` format string (use a TOML literal to avoid escaping); see https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+
+[currency_format]
+thousands_separator = '' # required, even if no separator is used, in which case set it to the empty string
+decimal_point = '.'      # required
 
 # The full YNAB4 header is: ['Date', 'Payee', 'Category', 'Memo', 'Outflow', 'Inflow']
 # Only 'Date' is strictly required to have a value, but having neither 'Outflow'
@@ -20,10 +24,10 @@ date_format = '%Y-%m-%d' # a valid `datetime.strptime` format string (use a TOML
 # The mapped names are case insensitive.
 #
 [ynab_mapping]
-date = 'Date' # required
+date = 'Date'       # required
 outflow = 'Outflow'
 inflow = 'Inflow'
 #amount = 'Amount' # can replace ynab_mapping.outflow and ynab_mapping.inflow
 payee = 'Payee'
 memo = 'Memo'
-category= 'Category'
+category = 'Category'

--- a/tests/example_csv/example_ynab.csv
+++ b/tests/example_csv/example_ynab.csv
@@ -1,0 +1,3 @@
+Date,Payee,Category,Memo,Outflow,Inflow
+2020-12-21,Sample Payee,,Sample Memo for an outflow,300.00,
+2021-01-01,Sample Payee 2,,Sample memo for an inflow,,1000.00

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from src.config import BankConfig
+from util import load_template_config
 
 import pytest
 
@@ -16,12 +17,16 @@ def test_parse_bank_configs(bank_config_files):
         BankConfig.from_file(config)
 
 
+def test_load_template_config():
+    config = load_template_config()
+    BankConfig.from_file(config)
+
 # ----------- Test invalid inputs -----------
 
 def test_invalid_config_empty():
     config = {}
     with pytest.raises(ValueError):
-        BankConfig(name=None, date_column=None, date_format=None)
+        BankConfig(name=None, date_column=None, date_format=None, currency_format=None)
 
 def test_invalid_config_empty_from_dict():
     config = {}
@@ -30,11 +35,12 @@ def test_invalid_config_empty_from_dict():
 
 def test_invalid_config_missing_date():
     with pytest.raises(ValueError):
-        BankConfig(name='N', date_format='DF', date_column=None)
+        BankConfig(name='N', date_format='DF', date_column=None, currency_format=None)
 
 def test_invalid_config_missing_date_from_dict():
     config = {
         'name': 'N',
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'csv': {'date_format': 'DF'},
         'ynab_mapping': {},
     }
@@ -44,6 +50,7 @@ def test_invalid_config_missing_date_from_dict():
 def test_invalid_config_empty_date_from_dict():
     config = {
         'name': 'N',
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'csv': {'date_format': 'DF'},
         'ynab_mapping': {'date': ''},
     }
@@ -52,11 +59,13 @@ def test_invalid_config_empty_date_from_dict():
 
 def test_invalid_config_missing_date_format():
     with pytest.raises(ValueError):
-        BankConfig(name='N', date_format=None, date_column='Date')
+        cf = {'thousands_separator': '', 'decimal_point': '.'},
+        BankConfig(name='N', date_format=None, date_column='Date', currency_format=cf)
 
 def test_invalid_config_missing_date_format_from_dict():
     config = {
         'name': 'N',
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'csv': {},
         'ynab_mapping': {'date': 'D'},
     }
@@ -66,6 +75,7 @@ def test_invalid_config_missing_date_format_from_dict():
 def test_invalid_config_missing_transaction_format():
     config = {
         'name': 'N',
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'csv': {'date_format': 'DF'},
         'ynab_mapping': {'date': 'D'},
     }
@@ -75,6 +85,7 @@ def test_invalid_config_missing_transaction_format():
 def test_invalid_config_amount_and_outflow_inflow():
     config = {
         'name': 'N',
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'csv': {'date_format': 'DF'},
         'ynab_mapping': {'date': 'D', 'amount': 'A', 'outflow': 'O', 'inflow':'I'},
     }
@@ -85,6 +96,7 @@ def test_invalid_config_amount_and_outflow():
     config = {
         'name': 'N',
         'csv': {'date_format': 'DF'},
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'ynab_mapping': {'date': 'D', 'amount': 'A', 'outflow': 'O'},
     }
     with pytest.raises(ValueError):
@@ -94,7 +106,32 @@ def test_invalid_config_amount_and_inflow():
     config = {
         'name': 'N',
         'csv': {'date_format': 'DF'},
+        'currency_format': {'thousands_separator': '', 'decimal_point': '.'},
         'ynab_mapping': {'date': 'D', 'amount': 'A', 'inflow':'I'},
     }
     with pytest.raises(ValueError):
         BankConfig.from_dict(config)
+
+def test_invalid_config_missing_currency_format():
+    config = {
+        'name': 'N',
+        'csv': {'date_format': 'DF'},
+        'ynab_mapping': {},
+    }
+    with pytest.raises(KeyError):
+        BankConfig.from_dict(config)
+
+def test_invalid_config_invalid_currency_format():
+    config = {
+        'name': 'N',
+        'csv': {'date_format': 'DF'},
+        'ynab_mapping': {},
+    }
+    fmts = [
+        {'thousands_separator': ',,', 'decimal_point': '.'},
+        {'thousands_separator': '', 'decimal_point': '..'},
+    ]
+    for fmt in fmts:
+        config['currency_format'] = fmt
+        with pytest.raises(ValueError):
+            BankConfig.from_dict(config)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from util import load_test_example, load_bank_config
+from util import load_test_example, load_bank_config, load_template_config, net_flow
 from scripts import fix_revolut
 from src.converter import bank2ynab
 from src.config import BankConfig
@@ -34,3 +34,17 @@ def test_revolut_v1(tmpdir):
     expect = (True, 0, 0, 6, 6)
     result = bank2ynab(revolut_config, fixed_file)
     assert expect == result
+
+def test_identity():
+    csv_path = load_test_example('example_ynab.csv')
+    toml_path =  load_template_config()
+    template_config = BankConfig.from_file(toml_path)
+
+    expect = (True, 0, 0, 2, 2)
+    result = bank2ynab(template_config, csv_path)
+    assert expect == result
+
+    net_bank = net_flow(csv_path)
+    net_converted = net_flow(Path.cwd() / 'ynabImport.csv')
+    assert net_bank == net_converted
+    print(f"{net_converted=}")

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,5 @@
+import csv
+from decimal import Decimal
 from pathlib import Path
 
 
@@ -37,8 +39,28 @@ def load_test_example(filename: str) -> Path:
 def load_bank_config(filename: str) -> Path:
     return _file_in_dir(filename, dir=bank_configs_dir())
 
+def load_template_config():
+    return _file_in_dir("template.toml", dir=bank_configs_dir() / "template")
+
 def _file_in_dir(filename: str, dir: Path) -> Path:
     for file in dir.iterdir():
         if file.name == filename:
             return file
     raise FileNotFoundError(f"{filename.name} could be found in {dir}")
+
+def _str_to_decimal(decimal: str ) -> Decimal:
+    if decimal == '':
+        return Decimal('0')
+
+    return Decimal(decimal)
+
+
+def net_flow(ynab_csv: Path) -> Decimal:
+    net = Decimal('0')
+    with ynab_csv.open('r', encoding="utf-8-sig", newline='') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            outflow, inflow = [_str_to_decimal(row[key]) for key in ('Outflow', 'Inflow')]
+            net = net + inflow - outflow
+
+    return net


### PR DESCRIPTION
# Motivation
Before this, I did not even bother to parse any monetary columns; I just copied them directly to the YNAB-import CSV, possibly adding a minus sign if it was an "`Amount`".
However, there is a need to support multiple monetary columns per statement row.
For example, a transaction column plus a fee column.
These must be summed to calculate the net flow and must therefore be parsed as numerical values.

# Changes

* Read monetary columns as  `Decimal` values. 
  *  `Decimal` gives exact calculations without the rounding errors of floats, which is ideal in this context.
* Configuration values for thousands separator and decimal point used for monetary columns.
  * These values are required in all bank configs. 
* Includes additional refactoring, such as more warnings and errors.
* The `test_identity` test is actually a regression test for a bug I discovered that the other tests did not capture since they do not look at the output CSV. In any case, it's a sensible test to have.